### PR TITLE
Fix string escaping in debug test

### DIFF
--- a/test/regular_expression_test.rb
+++ b/test/regular_expression_test.rb
@@ -150,7 +150,7 @@ class RegularExpressionTest < Minitest::Test
   end
 
   def test_debug
-    source = "^\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\d\D\w\W|.)\z$"
+    source = "^\\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\\d\\D\\w\\W|.)\\z$"
 
     ast = RegularExpression::Parser.new.parse(source)
     nfa = ast.to_nfa


### PR DESCRIPTION
This wasn’t testing what it was supposed to be testing, because the backslashes are treated as escape sequences, e.g. `"\A"` becomes `"A"`:

```
>> "^\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\d\D\w\W|.)\z$"
=> "^A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|dDwW|.)z$"
```

In general we should probably avoid double-quoted strings throughout the project, since almost all of our string literals are regular expressions (i.e. any escape sequences are intended for our regular expression engine), but that’s a larger and more contentious change so I’ll make it in a separate PR.