### PR TITLE
Use `%q{…}` syntax for all regular expression literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Style/IfUnlessModifier:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%q': '{}'
+    '%Q': '{}'
 
 Style/PerlBackrefs:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,10 @@ Style/HashEachMethods:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%q': '{}'
+
 Style/PerlBackrefs:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Style/IfUnlessModifier:
 Style/PerlBackrefs:
   Enabled: false
 
+Style/RedundantPercentQ:
+  Enabled: false
+
 Style/SpecialGlobalVars:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics:
 Style/AccessorGrouping:
   Enabled: false
 
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
 Style/CombinableLoops:
   Enabled: false
 

--- a/lib/regular_expression/ast.rb
+++ b/lib/regular_expression/ast.rb
@@ -156,16 +156,16 @@ module RegularExpression
 
       def to_nfa(start, finish)
         case value
-        when "\\w"
+        when %q{\w}
           start.add_transition(NFA::Transition::Range.new(finish, "a", "z"))
           start.add_transition(NFA::Transition::Range.new(finish, "A", "Z"))
           start.add_transition(NFA::Transition::Range.new(finish, "0", "9"))
           start.add_transition(NFA::Transition::Value.new(finish, "_"))
-        when "\\W"
+        when %q{\W}
           start.add_transition(NFA::Transition::Invert.new(finish, [*("a".."z"), *("A".."Z"), *("0".."9"), "_"]))
-        when "\\d"
+        when %q{\d}
           start.add_transition(NFA::Transition::Range.new(finish, "0", "9"))
-        when "\\D"
+        when %q{\D}
           start.add_transition(NFA::Transition::Range.new(finish, "0", "9", invert: true))
         else
           raise
@@ -240,9 +240,9 @@ module RegularExpression
       def to_nfa(start, finish)
         transition =
           case value
-          when "\\A"
+          when %q{\A}
             NFA::Transition::BeginAnchor.new(finish)
-          when "\\z", "$"
+          when %q{\z}, %q{$}
             NFA::Transition::EndAnchor.new(finish)
           end
 

--- a/lib/regular_expression/nfa.rb
+++ b/lib/regular_expression/nfa.rb
@@ -55,19 +55,19 @@ module RegularExpression
     module Transition
       class BeginAnchor < Struct.new(:state)
         def label
-          "\\A"
+          %q{\A}
         end
       end
 
       class EndAnchor < Struct.new(:state)
         def label
-          "\\z"
+          %q{\z}
         end
       end
 
       class Any < Struct.new(:state)
         def label
-          "."
+          %q{.}
         end
       end
 

--- a/lib/regular_expression/nfa.rb
+++ b/lib/regular_expression/nfa.rb
@@ -87,7 +87,7 @@ module RegularExpression
         end
 
         def label
-          "[^#{values.join}]"
+          %Q{[^#{values.join}]}
         end
       end
 
@@ -104,7 +104,7 @@ module RegularExpression
         end
 
         def label
-          "#{left}-#{right}"
+          %Q{#{left}-#{right}}
         end
       end
 

--- a/test/regular_expression_test.rb
+++ b/test/regular_expression_test.rb
@@ -4,137 +4,137 @@ require "test_helper"
 
 class RegularExpressionTest < Minitest::Test
   def test_basic
-    assert_matches("abc", "abc")
-    assert_matches("abc", "!abc")
+    assert_matches(%q{abc}, "abc")
+    assert_matches(%q{abc}, "!abc")
   end
 
   def test_optional
-    assert_matches("abc?", "ab")
-    assert_matches("abc?", "abc")
-    refute_matches("abc?", "ac")
+    assert_matches(%q{abc?}, "ab")
+    assert_matches(%q{abc?}, "abc")
+    refute_matches(%q{abc?}, "ac")
   end
 
   def test_alternation
-    assert_matches("ab|bc", "ab")
-    assert_matches("ab|bc", "bc")
-    refute_matches("ab|bc", "ac")
+    assert_matches(%q{ab|bc}, "ab")
+    assert_matches(%q{ab|bc}, "bc")
+    refute_matches(%q{ab|bc}, "ac")
   end
 
   def test_alternation_backtracking
-    assert_matches("ab|ac", "ab")
-    assert_matches("ab|ac", "ac")
-    refute_matches("ab|ac", "bc")
+    assert_matches(%q{ab|ac}, "ab")
+    assert_matches(%q{ab|ac}, "ac")
+    refute_matches(%q{ab|ac}, "bc")
   end
 
   def test_begin_anchor_caret
-    assert_matches("^abc", "abc")
-    refute_matches("^abc", "!abc")
+    assert_matches(%q{^abc}, "abc")
+    refute_matches(%q{^abc}, "!abc")
   end
 
   def test_begin_anchor_a
-    assert_matches("\\Aabc", "abc")
-    refute_matches("\\Aabc", "!abc")
+    assert_matches(%q{\Aabc}, "abc")
+    refute_matches(%q{\Aabc}, "!abc")
   end
 
   def test_end_anchor_dollar_sign
-    assert_matches("abc$", "abc")
-    refute_matches("abc$", "abc!")
+    assert_matches(%q{abc$}, "abc")
+    refute_matches(%q{abc$}, "abc!")
   end
 
   def test_end_anchor_z
-    assert_matches("abc\\z", "abc")
-    refute_matches("abc\\z", "abc!")
+    assert_matches(%q{abc\z}, "abc")
+    refute_matches(%q{abc\z}, "abc!")
   end
 
   def test_ranges_exact
-    assert_matches("a{2}", "aa")
-    refute_matches("a{2}", "a")
+    assert_matches(%q{a{2}}, "aa")
+    refute_matches(%q{a{2}}, "a")
   end
 
   def test_ranges_minimum
-    assert_matches("a{2,}", "aa")
-    assert_matches("a{2,}", "aaaa")
-    refute_matches("a{2,}", "a")
+    assert_matches(%q{a{2,}}, "aa")
+    assert_matches(%q{a{2,}}, "aaaa")
+    refute_matches(%q{a{2,}}, "a")
   end
 
   def test_ranges_minimum_and_maximum
-    assert_matches("a{2,5}", "aaa")
-    assert_matches("a{2,5}", "aaaaa")
-    refute_matches("a{2,5}", "a")
+    assert_matches(%q{a{2,5}}, "aaa")
+    assert_matches(%q{a{2,5}}, "aaaaa")
+    refute_matches(%q{a{2,5}}, "a")
   end
 
   def test_star
-    assert_matches("a*", "")
-    assert_matches("a*", "a")
-    assert_matches("a*", "aa")
+    assert_matches(%q{a*}, "")
+    assert_matches(%q{a*}, "a")
+    assert_matches(%q{a*}, "aa")
   end
 
   def test_plus
-    assert_matches("a+", "a")
-    assert_matches("a+", "aa")
-    refute_matches("a+", "")
+    assert_matches(%q{a+}, "a")
+    assert_matches(%q{a+}, "aa")
+    refute_matches(%q{a+}, "")
   end
 
   def test_character_range
-    assert_matches("[a-z]", "a")
-    assert_matches("[a-z]", "z")
-    refute_matches("[a-z]", "A")
+    assert_matches(%q{[a-z]}, "a")
+    assert_matches(%q{[a-z]}, "z")
+    refute_matches(%q{[a-z]}, "A")
   end
 
   def test_character_set
-    assert_matches("[abc]", "a")
-    assert_matches("[abc]", "c")
-    refute_matches("[abc]", "d")
+    assert_matches(%q{[abc]}, "a")
+    assert_matches(%q{[abc]}, "c")
+    refute_matches(%q{[abc]}, "d")
   end
 
   def test_character_class_d
-    assert_matches("\\d", "0")
-    refute_matches("\\d", "a")
+    assert_matches(%q{\d}, "0")
+    refute_matches(%q{\d}, "a")
   end
 
   def test_character_class_d_invert
-    assert_matches("\\D", "a")
-    refute_matches("\\D", "0")
+    assert_matches(%q{\D}, "a")
+    refute_matches(%q{\D}, "0")
   end
 
   def test_character_class_w
-    assert_matches("\\w", "a")
-    refute_matches("\\w", "!")
+    assert_matches(%q{\w}, "a")
+    refute_matches(%q{\w}, "!")
   end
 
   def test_character_class_w_invert
-    assert_matches("\\W", "!")
-    refute_matches("\\W", "a")
+    assert_matches(%q{\W}, "!")
+    refute_matches(%q{\W}, "a")
   end
 
   def test_character_group
-    assert_matches("[a-ce]", "b")
-    assert_matches("[a-ce]", "e")
-    refute_matches("[a-ce]", "d")
+    assert_matches(%q{[a-ce]}, "b")
+    assert_matches(%q{[a-ce]}, "e")
+    refute_matches(%q{[a-ce]}, "d")
   end
 
   def test_character_set_inverted
-    assert_matches("[^a-ce]", "d")
-    assert_matches("[^a-ce]", "f")
-    refute_matches("[^a-ce]", "a")
+    assert_matches(%q{[^a-ce]}, "d")
+    assert_matches(%q{[^a-ce]}, "f")
+    refute_matches(%q{[^a-ce]}, "a")
   end
 
   def test_period
-    assert_matches(".", "a")
-    assert_matches(".", "z")
-    refute_matches(".", "")
+    assert_matches(%q{.}, "a")
+    assert_matches(%q{.}, "z")
+    refute_matches(%q{.}, "")
   end
 
   def test_group
-    assert_matches("a(b|c)", "ab")
-    assert_matches("a(b|c)", "ac")
-    refute_matches("a(b|c)", "a")
+    assert_matches(%q{a(b|c)}, "ab")
+    assert_matches(%q{a(b|c)}, "ac")
+    refute_matches(%q{a(b|c)}, "a")
   end
 
   def test_group_quantifier
-    assert_matches("a(b|c){2}", "abc")
-    assert_matches("a(b|c){2}", "acb")
-    refute_matches("a(b|c){2}", "ab")
+    assert_matches(%q{a(b|c){2}}, "abc")
+    assert_matches(%q{a(b|c){2}}, "acb")
+    refute_matches(%q{a(b|c){2}}, "ab")
   end
 
   def test_raises_syntax_errors
@@ -145,12 +145,12 @@ class RegularExpressionTest < Minitest::Test
 
   def test_raises_parse_errors
     assert_raises(Racc::ParseError) do
-      RegularExpression::Parser.new.parse("(")
+      RegularExpression::Parser.new.parse(%q{(})
     end
   end
 
   def test_debug
-    source = "^\\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\\d\\D\\w\\W|.)\\z$"
+    source = %q{^\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\d\D\w\W|.)\z$}
 
     ast = RegularExpression::Parser.new.parse(source)
     nfa = ast.to_nfa


### PR DESCRIPTION
Being consistent about this makes it less likely that escape sequence mistakes (e.g. #25) will slip through, and has the nice bonus that we can remove many hard-to-read occurrences of `\\`.

I chose `%q{…}` instead of single quotes because it’s more obviously intentional rather than looking like two programmers are having an edit war over whether to use single- or double-quoted strings in Ruby code. This deviates slightly from the Ruby Style Guide, which advises to [avoid `%q` unless absolutely necessary](https://rubystyle.guide/#percent-q) and [only use `{}` delimiters for actual regular expression literals](https://rubystyle.guide/#percent-literal-braces), but I think our use case is specialised enough that it’s okay to bend these rules.

For reviewers: have I missed any?