### PR TITLE
Update lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,4 +66,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.2.16
+   2.2.24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
The current `Gemfile.lock` was generated with slightly older versions of both Bundler and macOS. Updating it will avoid lockfile diff noise for anyone using newer versions of either.