### PR TITLE
Add support for space characters

### DIFF
--- a/lib/regular_expression/ast.rb
+++ b/lib/regular_expression/ast.rb
@@ -144,7 +144,7 @@ module RegularExpression
     end
 
     class CharacterClass
-      attr_reader :value # "\w" | "\W" | "\d" | "\D" | "\h"
+      attr_reader :value # "\w" | "\W" | "\d" | "\D" | "\h" | "\s"
 
       def initialize(value)
         @value = value
@@ -171,6 +171,13 @@ module RegularExpression
           start.add_transition(NFA::Transition::Range.new(finish, "a", "f"))
           start.add_transition(NFA::Transition::Range.new(finish, "A", "F"))
           start.add_transition(NFA::Transition::Range.new(finish, "0", "9"))
+        when %q{\s}
+          start.add_transition(NFA::Transition::Value.new(finish, " "))
+          start.add_transition(NFA::Transition::Value.new(finish, "\t"))
+          start.add_transition(NFA::Transition::Value.new(finish, "\r"))
+          start.add_transition(NFA::Transition::Value.new(finish, "\n"))
+          start.add_transition(NFA::Transition::Value.new(finish, "\f"))
+          start.add_transition(NFA::Transition::Value.new(finish, "\v"))
         else
           raise
         end

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -29,7 +29,7 @@ module RegularExpression
 
       until @source.empty?
         case @source
-        when /\A\\[wWdDh]/
+        when /\A\\[wWdDhs]/
           result << [:CHAR_CLASS, $&]
         when /\A(?:\\[Az]|\$)/
           result << [:ANCHOR, $&]

--- a/test/regular_expression_test.rb
+++ b/test/regular_expression_test.rb
@@ -113,6 +113,16 @@ class RegularExpressionTest < Minitest::Test
     refute_matches(%q{\h}, "!")
   end
 
+  def test_character_class_s
+    assert_matches(%q{\s}, " ")
+    assert_matches(%q{\s}, "\n")
+    assert_matches(%q{\s}, "\t")
+    assert_matches(%q{\s}, "\f")
+    assert_matches(%q{\s}, "\r")
+    assert_matches(%q{\s}, "\v")
+    refute_matches(%q{\s}, "!")
+  end
+
   def test_character_group
     assert_matches(%q{[a-ce]}, "b")
     assert_matches(%q{[a-ce]}, "e")
@@ -156,7 +166,7 @@ class RegularExpressionTest < Minitest::Test
   end
 
   def test_debug
-    source = %q{^\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\d\D\w\W\h|.)\z$}
+    source = %q{^\A(a?|b{2,3}|[cd]*|[e-g]+|[^h-jk]|\d\D\w\W\h\s|.)\z$}
 
     ast = RegularExpression::Parser.new.parse(source)
     nfa = ast.to_nfa


### PR DESCRIPTION
## Why is this needed

Fixes #26

## What does this do

I've added support for the `\s` character class. This means adding first support to the lexer to recognise it as a character class and then adding the semantics of `\s` when we generate the nfa graph.