### PR TITLE
Add a 'rake preflight' task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,8 @@ end
 Rake::Task["test"].enhance(["lib/regular_expression/parser.rb"])
 
 task default: :test
+
+task :preflight do
+  system("bundle exec rake test") || raise("Tests didn't pass!")
+  system("bundle exec rubocop --parallel") || raise("Rubocop failed!")
+end


### PR DESCRIPTION
This runs "bundle exec rake test" and "bundle exec rubocop --parallel", same as the Github Actions workflow. When/if we add more Github Actions we can add them to the preflight too.

My intent is for this to be used locally before checkin. That's what I'm doing with it.