### PR TITLE
Make the Lexer class easier to read and understand

### DIFF
--- a/lib/regular_expression.rb
+++ b/lib/regular_expression.rb
@@ -4,6 +4,7 @@ require "fisk"
 require "fisk/helpers"
 require "set"
 require "stringio"
+require "strscan"
 
 require_relative "./regular_expression/ast"
 require_relative "./regular_expression/bytecode"

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -33,7 +33,7 @@ module RegularExpression
           result << [:CHAR_CLASS, @scanner.matched]
         when @scanner.scan(/\\[Az]|\$/)
           result << [:ANCHOR, @scanner.matched]
-        when @scanner.scan(/[\^$()\[\]{}|*+?.\-,]/)
+        when @scanner.scan(/[()\[\]{}^$|*+?.\-,]/)
           result << [SINGLE[@scanner.matched], @scanner.matched]
         when @scanner.scan(/\d+/)
           result << [:INTEGER, @scanner.matched.to_i]

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -33,7 +33,7 @@ module RegularExpression
           result << [:CHAR_CLASS, @scanner.matched]
         when @scanner.scan(/\\[Az]|\$/)
           result << [:ANCHOR, @scanner.matched]
-        when @scanner.scan(/[()\[\]{}^$|*+?.\-,]/)
+        when @scanner.scan(/[()\[\]{}^$|*+?.,-]/)
           result << [SINGLE[@scanner.matched], @scanner.matched]
         when @scanner.scan(/\d+/)
           result << [:INTEGER, @scanner.matched.to_i]

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -29,15 +29,15 @@ module RegularExpression
 
       until @scanner.eos?
         case # rubocop:disable Style/EmptyCaseCondition
-        when @scanner.scan(/\A\\[wWdDhs]/)
+        when @scanner.scan(/\\[wWdDhs]/)
           result << [:CHAR_CLASS, @scanner.matched]
-        when @scanner.scan(/\A(?:\\[Az]|\$)/)
+        when @scanner.scan(/(?:\\[Az]|\$)/)
           result << [:ANCHOR, @scanner.matched]
-        when @scanner.scan(/\A[\^$()\[\]{}|*+?.\-,]/)
+        when @scanner.scan(/[\^$()\[\]{}|*+?.\-,]/)
           result << [SINGLE[@scanner.matched], @scanner.matched]
-        when @scanner.scan(/\A\d+/)
+        when @scanner.scan(/\d+/)
           result << [:INTEGER, @scanner.matched.to_i]
-        when @scanner.scan(/\A(?:\u0009|\u000A|\u000D|[\u0020-\uD7FF]|[\uE000-\uFFFD])/)
+        when @scanner.scan(/(?:\u0009|\u000A|\u000D|[\u0020-\uD7FF]|[\uE000-\uFFFD])/)
           result << [:CHAR, @scanner.matched]
         else
           raise SyntaxError, @scanner.rest

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -31,13 +31,13 @@ module RegularExpression
         case # rubocop:disable Style/EmptyCaseCondition
         when @scanner.scan(/\\[wWdDhs]/)
           result << [:CHAR_CLASS, @scanner.matched]
-        when @scanner.scan(/(?:\\[Az]|\$)/)
+        when @scanner.scan(/\\[Az]|\$/)
           result << [:ANCHOR, @scanner.matched]
         when @scanner.scan(/[\^$()\[\]{}|*+?.\-,]/)
           result << [SINGLE[@scanner.matched], @scanner.matched]
         when @scanner.scan(/\d+/)
           result << [:INTEGER, @scanner.matched.to_i]
-        when @scanner.scan(/(?:\u0009|\u000A|\u000D|[\u0020-\uD7FF]|[\uE000-\uFFFD])/)
+        when @scanner.scan(/\u0009|\u000A|\u000D|[\u0020-\uD7FF]|[\uE000-\uFFFD]/)
           result << [:CHAR, @scanner.matched]
         else
           raise SyntaxError, @scanner.rest


### PR DESCRIPTION
By using `StringScanner` we can remove some of the code and some of the noise from the scan patterns. I think this makes `Lexer` easier to understand.

Closes #33.