### PR TITLE
Add labels to states

### DIFF
--- a/lib/regular_expression/nfa.rb
+++ b/lib/regular_expression/nfa.rb
@@ -11,9 +11,11 @@ module RegularExpression
     end
 
     class State
+      attr_reader :label # String
       attr_reader :transitions # Array[Transition]
 
-      def initialize
+      def initialize(label = "")
+        @label = label
         @transitions = []
       end
 
@@ -24,7 +26,7 @@ module RegularExpression
       def to_dot(graph, visited)
         return visited[self] if visited.include?(self)
 
-        source = graph.add_node(object_id, label: "")
+        source = graph.add_node(object_id, label: label)
         visited[self] = source
 
         transitions.each do |transition|


### PR DESCRIPTION
This PR adds sequential labels (“1”, “2”, “3” etc) to the dot output.

Before:

![before](https://user-images.githubusercontent.com/3192/126342215-d68444e3-4de5-445e-83ec-88b05cd2c590.png)

After:

![after](https://user-images.githubusercontent.com/3192/126342231-17b02b19-d1fd-4bc4-83b2-62319c10379f.png)

This is mostly useful for #37, so that we can more easily compare the corresponding nodes between the original NFA and the resulting DFA, but it’s also just nice to have the nodes labelled so that we can refer to them.