### PR TITLE
Adds Capstone to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Or install it yourself as:
 
     $ gem install regular_expression
 
-To generate Dotfile output (to_dot) or run the tests, you'll need Graphviz installed. On a Mac you can "brew install graphviz", or on Ubuntu you can "sudo apt-get install graphviz". For other platforms, Googling "install graphviz" can tell you how.
+### Dependencies
+
+#### Capstone
+
+This library depends on Vapstone. On a Mac you can `brew install capstone`, or on Ubuntu you can `sudo apt-get install libcapstone-dev`. For other platforms, Googling _install capstone_ can tell you how.
+
+#### Graphviz
+
+To generate Dotfile output (to\_dot) or run the tests, you'll need Graphviz installed. On a Mac you can `brew install graphviz`, or on Ubuntu you can `sudo apt-get install graphviz`. For other platforms, Googling _install graphviz_ can tell you how.
 
 ## Usage
 
@@ -41,9 +49,7 @@ pattern.match?("ab") # => false
 
 ## Development
 
-To run the tests, you'll need Graphviz installed. On a Mac you can "brew install graphviz", or on Ubuntu you can "sudo apt-get install graphviz". For other platforms, Googling "install graphviz" can tell you how.
-
-After checking out the repo, run `bundle install` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After [installing the dependencies](#dependencies) checking out the repo, run `bundle install` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
When I was trying to run the project using the `README.md` instructions I got this error message on `bin/console`:

```
Could not open library 'capstone': dlopen(capstone, 0x0005): dlopen(): file not found: capstone. (LoadError)
```

<details>

```
bundler: failed to load command: bin/console (bin/console)
Traceback (most recent call last):
	30: from /usr/bin/bundle:23:in `<main>'
	29: from /usr/bin/bundle:23:in `load'
	28: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/exe/bundle:37:in `<top (required)>'
	27: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	26: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/exe/bundle:49:in `block in <top (required)>'
	25: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli.rb:24:in `start'
	24: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	23: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli.rb:30:in `dispatch'
	22: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	21: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	20: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	19: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli.rb:474:in `exec'
	18: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli/exec.rb:28:in `run'
	17: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli/exec.rb:63:in `kernel_load'
	16: from /Users/cuducos/.gem/ruby/2.6.0/gems/bundler-2.2.21/lib/bundler/cli/exec.rb:63:in `load'
	15: from bin/console:6:in `<top (required)>'
	14: from bin/console:6:in `require'
	13: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone.rb:11:in `<top (required)>'
	12: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone.rb:11:in `require'
	11: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/disassembler.rb:5:in `<top (required)>'
	10: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/disassembler.rb:5:in `require'
	 9: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/binding.rb:4:in `<top (required)>'
	 8: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/binding.rb:4:in `require'
	 7: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/binding/structs.rb:5:in `<top (required)>'
	 6: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/binding/structs.rb:5:in `require'
	 5: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/cs_version.rb:8:in `<top (required)>'
	 4: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/cs_version.rb:51:in `<module:Crabstone>'
	 3: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/crabstone-4.0.3/lib/crabstone/cs_version.rb:53:in `<module:Binding>'
	 2: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/ffi-1.15.3/lib/ffi/library.rb:99:in `ffi_lib'
	 1: from /Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/ffi-1.15.3/lib/ffi/library.rb:99:in `map'
/Users/cuducos/Dropbox/Projects/regular_expression/vendor/bundle/ruby/2.6.0/gems/ffi-1.15.3/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library 'capstone': dlopen(capstone, 0x0005): dlopen(): file not found: capstone. (LoadError)
Could not open library 'libcapstone.dylib': dlopen(libcapstone.dylib, 0x0005): dlopen(): file not found: libcapstone.dylib.
Could not open library 'libcapstone.so.4': dlopen(libcapstone.so.4, 0x0005): dlopen(): file not found: libcapstone.so.4.
Could not open library 'libcapstone.so.4.dylib': dlopen(libcapstone.so.4.dylib, 0x0005): dlopen(): file not found: libcapstone.so.4.dylib.
Could not open library 'libcapstone.so.3': dlopen(libcapstone.so.3, 0x0005): dlopen(): file not found: libcapstone.so.3.
Could not open library 'libcapstone.so.3.dylib': dlopen(libcapstone.so.3.dylib, 0x0005): dlopen(): file not found: libcapstone.so.3.dylib
```

</details>

`brew install capstone` fixed it, so I added it to the `README.md`.

Since I was there, I removed duplicated instructions (the same paragraph about Graphviz was in _Usage_ and in _Development_; now _Development_ links to the dependencies section instead).