### PR TITLE
Add `\` escaping in lexer

### DIFF
--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -28,10 +28,14 @@ module RegularExpression
 
       until @scanner.eos?
         case # rubocop:disable Style/EmptyCaseCondition
+        when @scanner.scan(/\\\\/)
+          result << [:CHAR, "\\"]
         when @scanner.scan(/\\[wWdDhHsS]/)
           result << [:CHAR_CLASS, @scanner.matched]
         when @scanner.scan(/\\[Az]|\$/)
           result << [:ANCHOR, @scanner.matched]
+        when @scanner.scan(/\\./)
+          result << [:CHAR, @scanner.matched[-1]]
         when @scanner.scan(/[()\[\]{}^$|*+?.,-]/)
           result << [SINGLE[@scanner.matched], @scanner.matched]
         when @scanner.scan(/\d+/)

--- a/lib/regular_expression/lexer.rb
+++ b/lib/regular_expression/lexer.rb
@@ -4,7 +4,6 @@ module RegularExpression
   class Lexer
     SINGLE = {
       "^" => :CARET,
-      "$" => :ENDING,
       "(" => :LPAREN,
       ")" => :RPAREN,
       "[" => :LBRACKET,

--- a/test/regular_expression/lexer_test.rb
+++ b/test/regular_expression/lexer_test.rb
@@ -46,6 +46,15 @@ module RegularExpression
       assert_tokens(",", [[:COMMA, ","]])
     end
 
+    def test_escape_backslashes
+      assert_tokens("\\\\s", [[:CHAR, "\\"], [:CHAR, "s"]])
+      assert_tokens("\\\\z", [[:CHAR, "\\"], [:CHAR, "z"]])
+    end
+
+    def test_escape_special_characters
+      assert_tokens("1\\+", [[:INTEGER, 1], [:CHAR, "+"]])
+    end
+
     private
 
     def assert_tokens(string, expected)

--- a/test/regular_expression/lexer_test.rb
+++ b/test/regular_expression/lexer_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RegularExpression
+  class LexerTest < Minitest::Test
+    def test_char_lists
+      assert_tokens("ab", [[:CHAR, "a"], [:CHAR, "b"]])
+    end
+
+    def test_known_character_class
+      assert_tokens("\\w", [[:CHAR_CLASS, "\\w"]])
+      assert_tokens("\\W", [[:CHAR_CLASS, "\\W"]])
+      assert_tokens("\\d", [[:CHAR_CLASS, "\\d"]])
+      assert_tokens("\\D", [[:CHAR_CLASS, "\\D"]])
+      assert_tokens("\\h", [[:CHAR_CLASS, "\\h"]])
+      assert_tokens("\\H", [[:CHAR_CLASS, "\\H"]])
+      assert_tokens("\\s", [[:CHAR_CLASS, "\\s"]])
+      assert_tokens("\\S", [[:CHAR_CLASS, "\\S"]])
+    end
+
+    def test_anchors
+      assert_tokens("\\z", [[:ANCHOR, "\\z"]])
+      assert_tokens("\\A", [[:ANCHOR, "\\A"]])
+      assert_tokens("$", [[:ANCHOR, "$"]])
+    end
+
+    def test_integer
+      assert_tokens("0", [[:INTEGER, 0]])
+    end
+
+    def test_symbols
+      assert_tokens("^", [[:CARET, "^"]])
+      assert_tokens("(", [[:LPAREN, "("]])
+      assert_tokens(")", [[:RPAREN, ")"]])
+      assert_tokens("[", [[:LBRACKET, "["]])
+      assert_tokens("]", [[:RBRACKET, "]"]])
+      assert_tokens("{", [[:LBRACE, "{"]])
+      assert_tokens("}", [[:RBRACE, "}"]])
+      assert_tokens("|", [[:PIPE, "|"]])
+      assert_tokens("*", [[:STAR, "*"]])
+      assert_tokens("+", [[:PLUS, "+"]])
+      assert_tokens("?", [[:QMARK, "?"]])
+      assert_tokens(".", [[:PERIOD, "."]])
+      assert_tokens("-", [[:DASH, "-"]])
+      assert_tokens(",", [[:COMMA, ","]])
+    end
+
+    private
+
+    def assert_tokens(string, expected)
+      actual = Lexer.new(string).tokens
+      assert_equal([false, "end"], actual.last, "Tokens must end with #{[false, 'end'].inspect}")
+      actual.pop
+      assert_equal(expected, actual)
+    end
+  end
+end

--- a/test/regular_expression_test.rb
+++ b/test/regular_expression_test.rb
@@ -174,6 +174,16 @@ class RegularExpressionTest < Minitest::Test
     refute_matches(%q{a(b|c){2}}, "ab")
   end
 
+  def test_escaped_backslash
+    assert_matches(%q{\\\\s}, "\\\\s")
+    refute_matches(%q{\\\\s}, " ")
+  end
+
+  def test_escaped_plus
+    assert_matches(%q{a\\+}, "a+")
+    refute_matches(%q{a\\+}, "a")
+  end
+
   def test_raises_syntax_errors
     assert_raises(SyntaxError) do
       RegularExpression::Parser.new.parse("\u0000")


### PR DESCRIPTION
Fixes #48

This PR is split in 2 commits:

1. Add tests for the lexer

2. Add `\` escaping to the lexer
  I decided to wrap escaped characters as `:CHAR`, so they're treated as such by the grammar and below.
  The rules in the lexer are now order-dependent -- is that avoidable?

I'm not sure about the implementation, I haven't done this before 😅. Let me know what you think.