### PR TITLE
Creates a demo website for the library

### DIFF
--- a/web-demo/Gemfile
+++ b/web-demo/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "regular_expression", path: "../"
+gem "sinatra"
+
+group :test, :development do
+  gem "rack-test"
+  gem "rspec-core"
+  gem "rspec-expectations"
+end

--- a/web-demo/Gemfile.lock
+++ b/web-demo/Gemfile.lock
@@ -1,0 +1,46 @@
+PATH
+  remote: ..
+  specs:
+    regular_expression (0.1.0)
+      fisk
+      racc
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.4.4)
+    fisk (2.0.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    racc (1.5.2)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    ruby2_keywords (0.0.5)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  universal-darwin-20
+
+DEPENDENCIES
+  rack-test
+  regular_expression!
+  rspec-core
+  rspec-expectations
+  sinatra
+
+BUNDLED WITH
+   2.2.21

--- a/web-demo/README.md
+++ b/web-demo/README.md
@@ -1,0 +1,14 @@
+# RegularExpression web demo
+
+To start the server at [`localhost:9292`](http://localhost:9292):
+
+```console
+$ bundle install
+$ bundle exec rackup
+```
+
+## Tests
+
+```console
+$ bundle exec rspec app_test.rb
+```

--- a/web-demo/app.rb
+++ b/web-demo/app.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "json"
+require "regular_expression"
+require "sinatra/base"
+
+class App < Sinatra::Base
+  get "/" do
+    erb :index
+  end
+
+  post "/" do
+    content_type :json
+
+    body = request.body.read
+    return status(400) if body.empty?
+
+    data = JSON.parse(body)
+    return status(400) if !valid?(data, "pattern") || !valid?(data, "value")
+
+    pattern = RegularExpression::Pattern.new(data["pattern"])
+    { match: !pattern.match?(data["value"]).nil? }.to_json
+  end
+
+  private
+
+  def valid?(data, key)
+    !data[key].nil? && !data[key].strip.empty?
+  end
+end

--- a/web-demo/app_test.rb
+++ b/web-demo/app_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require_relative "app"
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+  config.expect_with(:rspec) { |c| c.syntax = %i[expect should] }
+end
+
+describe App do
+  let(:app) { App.new }
+  let(:headers) { { "Content-Type" => "application/json" } }
+
+  context "GET to /" do
+    let(:response) { get "/" }
+
+    it "returns HTTP status OK" do
+      expect(response.status).to eq 200
+    end
+  end
+
+  context "POST to / with a match" do
+    let(:body) { { pattern: "ab?c", value: "ac" }.to_json }
+    let(:response) { post "/", body, headers }
+
+    it "returns HTTP status OK" do
+      expect(response.status).to eq 200
+    end
+
+    it "returns application JSON" do
+      expect(response.headers["Content-type"]).to eq("application/json")
+    end
+
+    it "returns a match" do
+      expect(JSON.parse(response.body)).to eq({ "match" => true })
+    end
+  end
+
+  context "POST to / without a match" do
+    let(:body) { { pattern: "ab?c", value: "42" }.to_json }
+    let(:response) { post "/", body, headers }
+
+    it "returns HTTP status OK" do
+      expect(response.status).to eq 200
+    end
+
+    it "returns application JSON" do
+      expect(response.headers["Content-type"]).to eq("application/json")
+    end
+
+    it "does not return a match" do
+      expect(JSON.parse(response.body)).to eq({ "match" => false })
+    end
+  end
+
+  context "wrong POST to /" do
+    let(:body) { { foo: "bar" }.to_json }
+    let(:response) { post "/", body, headers }
+
+    it "returns HTTP status Bad Request" do
+      expect(response.status).to eq 400
+    end
+  end
+
+  context "empty POST to /" do
+    let(:response) { post "/", {}.to_json, headers }
+
+    it "returns HTTP status Bad Request" do
+      expect(response.status).to eq 400
+    end
+  end
+end

--- a/web-demo/config.ru
+++ b/web-demo/config.ru
@@ -1,0 +1,3 @@
+require_relative 'app'
+
+run App

--- a/web-demo/public/app.css
+++ b/web-demo/public/app.css
@@ -1,0 +1,2 @@
+body > .grid { height: 100% }
+.column { max-width: 36% }

--- a/web-demo/public/app.js
+++ b/web-demo/public/app.js
@@ -1,0 +1,86 @@
+const results = {
+  match: {
+    icon: ["check", "circle"],
+    text: "That's a match!",
+    color: "teal",
+  },
+  noMatch: {
+    icon: ["exclamation", "triangle"],
+    text: "That's not a match!",
+    color: "yellow",
+  },
+  notAnExpression: {
+    icon: ["times", "circle"],
+    text: "Invalid regular expression",
+    color: "red",
+  },
+};
+
+const colors = Object.keys(results).map((key) => results[key].color);
+const icons = Object.keys(results)
+  .map((key) => results[key].icon)
+  .flat()
+  .filter((value, index, self) => self.indexOf(value) === index);
+
+const render = (result) => {
+  const target = document.querySelector("div.ui.massive.label");
+  const icon = target.querySelector("i");
+  const text = target.querySelector("span");
+
+  colors.forEach((name) => target.classList.remove(name));
+  icons.forEach((name) => icon.classList.remove(name));
+
+  target.classList.add(result.color);
+  result.icon.forEach((name) => icon.classList.add(name));
+  text.innerHTML = result.text;
+};
+
+const dataFromForm = () => {
+  const form = document.forms[0];
+  return {
+    pattern: form.pattern.value,
+    value: form.value.value,
+  };
+};
+
+const shouldSubmit = () => {
+  const data = dataFromForm();
+  return data.pattern.trim().length > 0 && data.value.length > 0;
+};
+
+const handleResponse = (response) => {
+  if (response.status !== 200) {
+    return results.notAnExpression;
+  }
+
+  return response
+    .json()
+    .then((data) => {
+      const result = data.match ? results.match : results.noMatch;
+      render(result);
+    })
+    .catch(() => render(results.notAnExpression));
+};
+
+const submit = () => {
+  if (!shouldSubmit()) {
+    return;
+  }
+
+  const config = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(dataFromForm()),
+  };
+  fetch("/", config).then(handleResponse).catch(handleResponse);
+};
+
+const attachEvents = () => {
+  const form = document.forms[0];
+  const fields = ["pattern", "value"];
+
+  fields.forEach((field) => form[field].addEventListener("keyup", submit));
+  form.addEventListener("submit", () => false);
+};
+
+document.addEventListener("DOMContentLoaded", attachEvents);

--- a/web-demo/views/index.erb
+++ b/web-demo/views/index.erb
@@ -1,0 +1,53 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>RegularExpression</title>
+    <meta name="description" content="A regular expression engine written in Ruby">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
+    <link rel="stylesheet" href="/app.css">
+    <script src="/app.js"></script>
+  </head>
+
+  <body>
+    <div class="ui middle aligned center aligned grid">
+      <div class="column">
+        <h2 class="ui teal image header">
+          <div class="content">
+            RegularExpression
+          </div>
+        </h2>
+        <p>A regular expression engine written in Ruby</p>
+        <form class="ui large form">
+          <div class="ui stacked segment">
+            <div class="field">
+              <div class="ui left icon input">
+                <i class="code icon"></i>
+                <input type="text" name="pattern" placeholder="Regular expression">
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui left icon input">
+                <i class="align left icon"></i>
+                <input type="text" name="value" placeholder="Text">
+              </div>
+            </div>
+            <div class="ui massive label teal">
+              <i class="check circle icon"></i>
+              <span>That's a match!</span>
+            </div>
+          </div>
+        </form>
+        <div class="ui hidden divider"></div>
+        <p>
+          <a href="https://github.com/kddnewton/regular_expression/" class="ui compact labeled icon button">
+            <i class="github icon"></i>
+            Source code
+          </a>
+        </p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
The web app is created under `web-demo/`. Default commands for installing (`bundler install`), testing (`bundle exec rspec app_test.rb`) and running the server (`bundle exec rackup`):

https://user-images.githubusercontent.com/4732915/126407716-eaa52a7a-8241-476f-9bf6-d19ee53d0b2b.mov

Surely more features can be added next, e.g.: the SVG output, a benchmark against Ruby's native library…