### PR TITLE
Add profile-directed compilation

### DIFF
--- a/lib/regular_expression/pattern.rb
+++ b/lib/regular_expression/pattern.rb
@@ -13,12 +13,18 @@ module RegularExpression
       cfg = CFG.build(bytecode)
       schedule = Scheduler.schedule(cfg)
 
-      singleton_class.undef_method(:match?)
-      define_singleton_method(:match?, &compiler.compile(cfg, schedule))
+      redefine_match(&compiler.compile(cfg, schedule))
     end
 
     def match?(string)
       Interpreter.new(bytecode).match?(string)
+    end
+
+    private
+
+    def redefine_match(&block)
+      singleton_class.undef_method(:match?)
+      define_singleton_method(:match?, &block)
     end
   end
 end

--- a/lib/regular_expression/pattern.rb
+++ b/lib/regular_expression/pattern.rb
@@ -16,6 +16,25 @@ module RegularExpression
       redefine_match(&compiler.compile(cfg, schedule))
     end
 
+    def profile(compiler: Compiler::X86, threshold: 100)
+      interpreter = Interpreter.new(bytecode)
+      profiling_data = Interpreter.empty_profiling_data
+      iteration = threshold
+
+      # Replace with a profiling interpreter version of match?
+      redefine_match do |string|
+        if (iteration -= 1).negative?
+          cfg = CFG.build(bytecode, profiling_data)
+          schedule = Scheduler.schedule(cfg)
+
+          # Replace with a compiled version of match?
+          redefine_match(&compiler.compile(cfg, schedule))
+        end
+
+        interpreter.interpret(string, profiling_data)
+      end
+    end
+
     def match?(string)
       Interpreter.new(bytecode).match?(string)
     end

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -329,7 +329,7 @@ module RegularExpression
     end
 
     def refute_matches(source, value)
-      message = "Expected /#{source}/ to match #{value.inspect} (#{compiler})"
+      message = "Expected /#{source}/ to not match #{value.inspect} (#{compiler})"
       refute_operator assertion_pattern(source), :match?, value, message
     end
   end

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -294,12 +294,14 @@ module RegularExpression
       nfa = ast.to_nfa
       bytecode = Bytecode.compile(nfa)
       cfg = CFG.build(bytecode)
+      schedule = Scheduler.schedule(cfg)
 
       interpreter = Interpreter.new(bytecode)
       assert_kind_of(Proc, interpreter.to_proc)
 
       assert_kind_of(String, bytecode.dump)
       assert_kind_of(String, cfg.dump)
+      assert_kind_of(String, Scheduler.dump(cfg, schedule))
 
       assert_kind_of(String, AST.to_dot(ast))
       assert_kind_of(String, NFA.to_dot(nfa))


### PR DESCRIPTION
The idea is that we run a pattern in the interpreter initially, gathering profiling information, then we use that profiling information to inform how we compile - in practice meaning how we schedule.

For example, given the pattern `a?b`.

Without profiling, we default to say that we assume true-branches are most likely to be taken.

<img width="1143" alt="Screenshot 2021-07-21 at 22 44 42" src="https://user-images.githubusercontent.com/341094/126564238-3feae90a-6cdd-4b69-a475-95fabea6ebb6.png">

We get the same thing if we profile or train the pattern against `ab`.

<img width="1143" alt="Screenshot 2021-07-21 at 22 44 42" src="https://user-images.githubusercontent.com/341094/126564344-6a276eeb-1b99-4db4-b1e9-2f86ebd93ffd.png">

But if we profile against the pattern `x`, we now see different branch probabilities.

<img width="1147" alt="Screenshot 2021-07-21 at 22 46 48" src="https://user-images.githubusercontent.com/341094/126564458-f53b8c10-634b-4882-acaa-5b944a72ce58.png">

These profiles aren't binary - if we have a more complex pattern and train it against many inputs we can see varying probabilities.

<img width="1484" alt="Screenshot 2021-07-21 at 22 47 42" src="https://user-images.githubusercontent.com/341094/126564598-8f889239-aa4e-4063-90ab-33abea2e2968.png">

What does this achieve in practice? Going back to `a?b` - here is a compiled version profiled against a matching string compared to one profiled against a failing string.

```ruby
-> (string) {
  start_n = 0
  stack = []
  captures = {}
  while start_n <= string.size
    string_n = start_n
    block = :state_1480_0
    loop do
      case block
      when :state_1480_0
        captures["$0"] ||= {}
        captures["$0"][:start] = string_n
        # falls through
      # state_1500_0:
        stack << string_n
        flag = string_n < string.size && string[string_n] == "a"
        string_n += 1 if flag
        if flag
          block = :state_1520_0
          next
        else
          block = :state_1520_0
          next
        end
      when :state_1520_0
        flag = string_n < string.size && string[string_n] == "b"
        string_n += 1 if flag
        if flag
          # falls through
        else
          block = :fail
          next
        end
      # state_1540_0:
        captures["$0"][:end] = string_n
        # falls through
      # state_1560_0:
        return captures
      when :fail
        start_n += 1
        break
      else
        raise "Encountered unknown block: #{block}"
      end
    end
  end
  nil
}
```

```ruby
-> (string) {
  start_n = 0
  stack = []
  captures = {}
  while start_n <= string.size
    string_n = start_n
    block = :state_1480_0
    loop do
      case block
      when :state_1480_0
        captures["$0"] ||= {}
        captures["$0"][:start] = string_n
        # falls through
      # state_1500_0:
        stack << string_n
        flag = string_n < string.size && string[string_n] == "a"
        string_n += 1 if flag
        if flag
          block = :state_1520_0
          next
        else
          block = :state_1520_0
          next
        end
      when :state_1520_0
        flag = string_n < string.size && string[string_n] == "b"
        string_n += 1 if flag
        if flag
          block = :state_1540_0
          next
        else
          # falls through
        end
      # fail:
        start_n += 1
        break
      when :state_1540_0
        captures["$0"][:end] = string_n
        # falls through
      # state_1560_0:
        return captures
      else
        raise "Encountered unknown block: #{block}"
      end
    end
  end
  nil
}
```

Notice that we now fall through (defaulted) to failure, where before we fell-through to success.