### PR TITLE
More tests

### DIFF
--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -61,6 +61,11 @@ module RegularExpression
       refute_matches(%q{ab|ac}, "bc")
     end
 
+    test_matching(:multicharacter_backtracking) do
+      skip
+      assert_matches(%q{a?a?a?aaa}, "aaaaa")
+    end
+
     test_matching(:begin_anchor_caret) do
       assert_matches(%q{^abc}, "abc")
       refute_matches(%q{^abc}, "!abc")

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -66,6 +66,10 @@ module RegularExpression
       assert_matches(%q{a?a?a?aaa}, "aaaaa")
     end
 
+    test_matching(:larger_strings) do
+      assert_matches(%Q{#{'a'*50}b}, "#{'a'*50}b")
+    end
+
     test_matching(:begin_anchor_caret) do
       assert_matches(%q{^abc}, "abc")
       refute_matches(%q{^abc}, "!abc")

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -67,7 +67,7 @@ module RegularExpression
     end
 
     test_matching(:larger_strings) do
-      assert_matches(%Q{#{'a'*50}b}, "#{'a'*50}b")
+      assert_matches(%Q{#{'a' * 50}b}, "#{'a' * 50}b")
     end
 
     test_matching(:begin_anchor_caret) do


### PR DESCRIPTION
Add a skipped test for (failing again) multicharacter backtracking.

Add a test for strings around 50 characters long.
