### PR TITLE
Support passing flags to `bin/parse`

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 $:.unshift(File.expand_path("../lib", __dir__))
+require "optparse"
 require "bundler/setup"
 require "regular_expression"
 require "crabstone"
@@ -12,11 +13,29 @@ unless `which dot`.chomp.end_with?("dot")
        " Please install Graphviz if you want dotfile visual output to work."
 end
 
+options = {
+  flags: RegularExpression::Flags.new
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~DESC
+    Parses a regular expression, prints debugging information to string, \
+    generates graphiz information in the build directory, and runs it \
+    against the provided input strings (if any).
+
+    Usage: bin/parse pattern [input ...]
+  DESC
+
+  opts.on("-f", "--flags FLAGS", "Regexp flags as string (example: x for Regexp::EXTENDED)") do |str|
+    options[:flags] = RegularExpression::Flags.parse(str)
+  end
+end.parse!
+
 # Pass the source through the various parsing phases
 #
 source = ARGV.shift
 
-ast = RegularExpression::Parser.new.parse(source)
+ast = RegularExpression::Parser.new.parse(source, options[:flags])
 RegularExpression::AST.to_dot(ast)
 
 nfa = ast.to_nfa

--- a/lib/regular_expression/flags.rb
+++ b/lib/regular_expression/flags.rb
@@ -6,6 +6,19 @@ module RegularExpression
   class Flags
     attr_reader :value
 
+    CODES = {
+      "x" => Regexp::EXTENDED
+    }.freeze
+
+    # Parses a String into a Flags object.
+    def self.parse(str)
+      flags = str.each_char.map do |flag|
+        CODES.fetch(flag) { raise ArgumentError, "Unsupported flag: #{flag}" }
+      end
+
+      new(flags.reduce(&:|))
+    end
+
     def initialize(value = nil)
       @value = value || 0
     end

--- a/test/regular_expression/flags_test.rb
+++ b/test/regular_expression/flags_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RegularExpression
+  class FlagsTest < Minitest::Test
+    def test_parse_accepts_string
+      assert(Flags.parse("x").extended?)
+    end
+
+    def test_initializer_accepts_bit_flags
+      assert(Flags.new(Regexp::EXTENDED).extended?)
+    end
+
+    def test_extended
+      assert(Flags.new(Regexp::EXTENDED).extended?)
+      refute(Flags.new.extended?)
+    end
+
+    def test_unknown_flag_raises
+      assert_raises(ArgumentError) do
+        Flags.parse("z")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for flags in `bin/parse`, using the `-f` (`--flag`) named argument. I chose the name argument to not interfere with its current (nice) API.

To handle the argument parsing, I used Ruby stdlib's `OptionParser`, and added a bit of doc to the command:

```
$ bin/parse --help
Parses a regular expression, prints debugging information to string, generates graphiz information in the build directory, and runs it against the provided input strings (if any).

Usage: bin/parse pattern [input ...]
    -f, --flags FLAGS                Regexp flags as string (example: x for Regexp::EXTENDED)
```

I also extended the Flags initializer to accept strings and bit flags. This part is slighly more controversial -- Ruby doesn't do that. the string representation to bits happens  -> bit flag happens in the `Flags` class.