### PR TITLE
Collect x86 instructions in StringIO

### DIFF
--- a/lib/regular_expression/compiler/x86.rb
+++ b/lib/regular_expression/compiler/x86.rb
@@ -41,9 +41,9 @@ module RegularExpression
       # two levels!
       def self.compile(cfg, schedule)
         fisk = Fisk.new
-        buffer = Fisk::Helpers.jitbuffer(1024)
+        stringio = StringIO.new("".b)
 
-        fisk.asm(buffer) do
+        fisk.asm(stringio) do
           # Here we're setting up a couple of local variables that point to
           # registers so that it's easier to see what's actually going on
 
@@ -454,6 +454,10 @@ module RegularExpression
 
           ret
         end
+
+        buffer = Fisk::Helpers.jitbuffer(stringio.size)
+        stringio.rewind
+        stringio.each_byte(&buffer.method(:putc))
 
         Compiled.new(buffer)
       end


### PR DESCRIPTION
Fixes #74

Before this commit, the allocated buffer was fixed in size which
segfaulted on large patterns. For example, this test failed prior to
this commit:

```diff
diff --git test/regular_expression/matching_test.rb test/regular_expression/matching_test.rb
index 1b13109..059a97c 100644
--- test/regular_expression/matching_test.rb
+++ test/regular_expression/matching_test.rb
@@ -31,6 +31,10 @@ module RegularExpression
       end
     end

+    test_matching(:very_long_pattern) do
+      assert_matches(%q{a} * 100, "a" * 100)
+    end
+
     test_matching(:basic) do
       assert_matches(%q{abc}, "abc")
       assert_matches(%q{abc}, "!abc")

```