### PR TITLE
Cranelift

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      BUNDLE_JOBS: 1
     steps:
     - name: Install graphviz
       run: sudo apt-get install graphviz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
+      BUNDLE_JOBS: 1
     steps:
     - name: Install graphviz
       run: sudo apt-get install graphviz
     - uses: actions/checkout@master
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
@@ -28,6 +34,11 @@ jobs:
       CI: true
     steps:
     - uses: actions/checkout@master
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     regular_expression (0.1.0)
+      cranelift_ruby
       fisk
       racc
 
@@ -11,6 +12,8 @@ GEM
     ast (2.4.2)
     crabstone (4.0.3)
       ffi
+    cranelift_ruby (0.1.1)
+      rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)
     fisk (2.1.0)
@@ -43,6 +46,7 @@ GEM
     rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    rutie (0.0.4)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     ast (2.4.2)
     crabstone (4.0.3)
       ffi
-    cranelift_ruby (0.1.2)
+    cranelift_ruby (0.1.6)
       rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     ast (2.4.2)
     crabstone (4.0.3)
       ffi
-    cranelift_ruby (0.1.1)
+    cranelift_ruby (0.1.2)
       rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)

--- a/bench/run_benchmarks.rb
+++ b/bench/run_benchmarks.rb
@@ -26,7 +26,8 @@ BENCHMARKS = {
     [%q{a{25,50}b}, "#{'a' * 37}c", false, 1_000],
   ],
   "tricky" => [
-    [%q{(a?){10}a{10}}, "a" * 15, true, 1_000, { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }],
+    [%q{(a?){10}a{10}}, "a" * 15, true, 1_000,
+     { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }],
     [%Q{#{'a?' * 10}#{'a' * 10}}, "a" * 15, true, 1_000,
      { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }]
   ],

--- a/bench/run_benchmarks.rb
+++ b/bench/run_benchmarks.rb
@@ -26,9 +26,9 @@ BENCHMARKS = {
     [%q{a{25,50}b}, "#{'a' * 37}c", false, 1_000],
   ],
   "tricky" => [
-    [%q{(a?){10}a{10}}, "a" * 15, true, 1_000, { uncompiled: false, compiled_x86: false, compiled_ruby: false }],
+    [%q{(a?){10}a{10}}, "a" * 15, true, 1_000, { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }],
     [%Q{#{'a?' * 10}#{'a' * 10}}, "a" * 15, true, 1_000,
-     { uncompiled: false, compiled_x86: false, compiled_ruby: false }]
+     { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }]
   ],
 
   # Benchmarks from Shopify's UserAgent sniffing code
@@ -38,7 +38,7 @@ BENCHMARKS = {
       "Shopify Mobile/iOS/5.4.4 "\
       "(iPhone9,3/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 10, minorVersion: 3, patchVersion: 2))",
       true, 100,
-      { uncompiled: false, compiled_x86: false, compiled_ruby: false }
+      { uncompiled: false, compiled_x86: false, compiled_ruby: false, compiled_cranelift: false }
     ]
   ]
 }.freeze
@@ -78,6 +78,7 @@ def time_all_matches(source, value, should_match: true, iters_per_batch: 100, op
     next if samples_name == :re && options[:uncompiled] == false
     next if samples_name == :re_x86 && options[:compiled_x86] == false
     next if samples_name == :re_ruby && options[:compiled_ruby] == false
+    next if samples_name == :re_cranelift && options[:compiled_cranelift] == false
 
     did_match = match_obj.match?(value)
 

--- a/bench/run_benchmarks.rb
+++ b/bench/run_benchmarks.rb
@@ -71,7 +71,7 @@ def time_all_matches(source, value, should_match: true, iters_per_batch: 100, op
     [Regexp.new(source), :ruby, "Ruby built-in regexp"],
     [re_basic, :re, "uncompiled RegularExpression object"],
     [re_x86, :re_x86, "RegularExpression x86 compiler"],
-    [re_ruby, :re_ruby, "RegularExpression Ruby-backend compiler"]
+    [re_ruby, :re_ruby, "RegularExpression Ruby-backend compiler"],
     [re_cranelift, :re_cranelift, "RegularExpression cranelift compiler"]
   ].each do |match_obj, samples_name, matcher_description|
     next if samples_name == :ruby && options[:native] == false
@@ -158,12 +158,12 @@ BENCHMARKS.each do |category, benchmarks|
     bench_pcts = []
     bench_means = []
     bench_rsds = []
-    %i[ruby re re_x86 re_ruby, re_cranelift].each_with_index do |impl, impl_idx|
+    %i[ruby re re_x86 re_ruby re_cranelift].each_with_index do |impl, impl_idx|
       if (impl == :ruby && options[:native] == false) ||
          (impl == :re && options[:uncompiled] == false) ||
          (impl == :re_x86 && options[:compiled_x86] == false) ||
          (impl == :re_ruby && options[:compiled_ruby] == false) ||
-         impl == :re_cranelift && options[:compiled_cranelift] == false)
+         (impl == :re_cranelift && options[:compiled_cranelift] == false)
         bench_pcts.push nil
         bench_rsds.push nil
         next

--- a/bin/parse
+++ b/bin/parse
@@ -5,9 +5,8 @@ $:.unshift(File.expand_path("../lib", __dir__))
 require "optparse"
 require "bundler/setup"
 require "regular_expression"
-require "crabstone"
+# require "crabstone"
 require "graphviz"
-
 unless `which dot`.chomp.end_with?("dot")
   warn "YOU HAVE NOT INSTALLED GRAPHVIZ. We found no 'dot' in your path.\n" \
        " Please install Graphviz if you want dotfile visual output to work."
@@ -58,7 +57,9 @@ ruby = RegularExpression::Compiler::Ruby.compile(cfg, schedule)
 puts "#{ruby.source}\n"
 
 x86 = RegularExpression::Compiler::X86.compile(cfg, schedule)
-puts "#{x86.disasm}\n"
+# puts "#{x86.disasm}\n"
+
+cranelift = RegularExpression::Compiler::Cranelift.compile(cfg, schedule)
 
 check =
   if ARGV.any?
@@ -80,6 +81,9 @@ check.call(ruby)
 
 # Test x86 against any passed strings
 check.call(x86)
+
+# Test cranelift against any passed strings
+check.call(cranelift)
 
 # Test out the profiling
 if ARGV.any?

--- a/bin/parse
+++ b/bin/parse
@@ -57,7 +57,7 @@ ruby = RegularExpression::Compiler::Ruby.compile(cfg, schedule)
 puts "#{ruby.source}\n"
 
 x86 = RegularExpression::Compiler::X86.compile(cfg, schedule)
-# puts "#{x86.disasm}\n"
+puts "#{x86.disasm}\n"
 
 cranelift = RegularExpression::Compiler::Cranelift.compile(cfg, schedule)
 

--- a/bin/parse
+++ b/bin/parse
@@ -5,7 +5,7 @@ $:.unshift(File.expand_path("../lib", __dir__))
 require "optparse"
 require "bundler/setup"
 require "regular_expression"
-# require "crabstone"
+require "crabstone"
 require "graphviz"
 unless `which dot`.chomp.end_with?("dot")
   warn "YOU HAVE NOT INSTALLED GRAPHVIZ. We found no 'dot' in your path.\n" \

--- a/bin/parse
+++ b/bin/parse
@@ -60,6 +60,7 @@ x86 = RegularExpression::Compiler::X86.compile(cfg, schedule)
 puts "#{x86.disasm}\n"
 
 cranelift = RegularExpression::Compiler::Cranelift.compile(cfg, schedule)
+puts "#{cranelift.disasm}\n"
 
 check =
   if ARGV.any?

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -2,12 +2,15 @@ PATH
   remote: ..
   specs:
     regular_expression (0.1.0)
+      cranelift_ruby
       fisk
       racc
 
 GEM
   remote: https://rubygems.org/
   specs:
+    cranelift_ruby (0.1.1)
+      rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)
     fisk (2.0.0)
@@ -33,6 +36,7 @@ GEM
       rack (>= 1.0, < 3)
     rake (13.0.6)
     ruby2_keywords (0.0.5)
+    rutie (0.0.4)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/regular_expression.rb
+++ b/lib/regular_expression.rb
@@ -4,6 +4,7 @@ require "fiddle"
 require "fisk"
 require "fisk/helpers"
 require "set"
+require "cranelift_ruby"
 require "stringio"
 require "strscan"
 
@@ -26,3 +27,4 @@ require_relative "./regular_expression/version"
 
 require_relative "./regular_expression/compiler/ruby"
 require_relative "./regular_expression/compiler/x86"
+require_relative "./regular_expression/compiler/cranelift"

--- a/lib/regular_expression/bytecode.rb
+++ b/lib/regular_expression/bytecode.rb
@@ -236,13 +236,21 @@ module RegularExpression
       attr_reader :insns # Array[Insns]
       attr_reader :labels # Hash[Symbol, Integer]
       attr_accessor :captures # Integer
+<<<<<<< HEAD
       attr_accessor :backtracks # Integer
+=======
+      attr_accessor :n_of_transitions
+>>>>>>> 12432bb (Add cranelift backend)
 
       def initialize
         @insns = []
         @labels = {}
         @captures = 0
+<<<<<<< HEAD
         @backtracks = 0
+=======
+        @n_of_transitions = 0
+>>>>>>> 12432bb (Add cranelift backend)
       end
 
       def mark_label(label)
@@ -254,18 +262,30 @@ module RegularExpression
       end
 
       def build
+<<<<<<< HEAD
         Compiled.new(insns, labels, captures, backtracks)
+=======
+        Compiled.new(insns, labels, captures, n_of_transitions)
+>>>>>>> 12432bb (Add cranelift backend)
       end
     end
 
     class Compiled
       attr_reader :insns, :labels, :captures, :backtracks
 
+<<<<<<< HEAD
       def initialize(insns, labels, captures, backtracks)
         @insns = insns
         @labels = labels
         @captures = captures
         @backtracks = backtracks
+=======
+      def initialize(insns, labels, captures, n_of_transitions)
+        @insns = insns
+        @labels = labels
+        @captures = captures
+        @n_of_transitions = n_of_transitions
+>>>>>>> 12432bb (Add cranelift backend)
       end
 
       def dump

--- a/lib/regular_expression/bytecode.rb
+++ b/lib/regular_expression/bytecode.rb
@@ -236,21 +236,13 @@ module RegularExpression
       attr_reader :insns # Array[Insns]
       attr_reader :labels # Hash[Symbol, Integer]
       attr_accessor :captures # Integer
-<<<<<<< HEAD
       attr_accessor :backtracks # Integer
-=======
-      attr_accessor :n_of_transitions
->>>>>>> 12432bb (Add cranelift backend)
 
       def initialize
         @insns = []
         @labels = {}
         @captures = 0
-<<<<<<< HEAD
         @backtracks = 0
-=======
-        @n_of_transitions = 0
->>>>>>> 12432bb (Add cranelift backend)
       end
 
       def mark_label(label)
@@ -262,30 +254,18 @@ module RegularExpression
       end
 
       def build
-<<<<<<< HEAD
         Compiled.new(insns, labels, captures, backtracks)
-=======
-        Compiled.new(insns, labels, captures, n_of_transitions)
->>>>>>> 12432bb (Add cranelift backend)
       end
     end
 
     class Compiled
       attr_reader :insns, :labels, :captures, :backtracks
 
-<<<<<<< HEAD
       def initialize(insns, labels, captures, backtracks)
         @insns = insns
         @labels = labels
         @captures = captures
         @backtracks = backtracks
-=======
-      def initialize(insns, labels, captures, n_of_transitions)
-        @insns = insns
-        @labels = labels
-        @captures = captures
-        @n_of_transitions = n_of_transitions
->>>>>>> 12432bb (Add cranelift backend)
       end
 
       def dump

--- a/lib/regular_expression/compiler/cranelift.rb
+++ b/lib/regular_expression/compiler/cranelift.rb
@@ -4,10 +4,28 @@ module RegularExpression
   module Compiler
     module Cranelift
       class Compiled
-        attr_reader :f_ptr
+        attr_reader :f_ptr, :f_size
 
-        def initialize(f_ptr)
+        def initialize(f_ptr, f_size)
           @f_ptr = f_ptr
+          @f_size = f_size
+        end
+
+        def disasm
+          output = StringIO.new
+
+          crabstone = Crabstone::Disassembler.new(Crabstone::ARCH_X86, Crabstone::MODE_64)
+          ptr = Fiddle::Pointer.new(f_ptr)
+          crabstone.disasm(ptr[0, f_size], f_ptr).each do |insn|
+            output.printf(
+              "0x%<address>x:\t%<instruction>s\t%<details>s\n",
+              address: insn.address,
+              instruction: insn.mnemonic,
+              details: insn.op_str
+            )
+          end
+
+          output.string
         end
 
         def to_proc
@@ -17,6 +35,12 @@ module RegularExpression
             value if value != string.length + 1
           end
         end
+      end
+
+      def self.jump_to_next_block(bcx)
+        block = bcx.create_block
+        bcx.jump(block, [])
+        bcx.switch_to_block(block)
       end
 
       def self.compile(cfg, _schedule)
@@ -96,52 +120,52 @@ module RegularExpression
                 bcx.def_var(string_index, increased)
                 bcx.def_var(flag, flag_val)
               when Bytecode::Insns::TestValue
-                post_length_check_block = bcx.create_block
                 end_block = bcx.create_block
+                
                 string_index_val = bcx.use_var(string_index)
                 bcx.def_var(flag, zero)
                 bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
-                bcx.jump(post_length_check_block, [])
-                bcx.switch_to_block(post_length_check_block)
+
+                jump_to_next_block(bcx)
                 char_ptr = bcx.iadd(string_pointer, string_index_val)
                 char = bcx.load(:I8, char_ptr, 0)
                 expected_char = bcx.iconst(:I8, insn.char.ord)
                 v = bcx.icmp(:e, char, expected_char)
                 flag_val = bcx.select(v, one, zero)
                 increased = bcx.iadd(string_index_val, flag_val)
+                
                 bcx.def_var(string_index, increased)
                 bcx.def_var(flag, flag_val)
                 bcx.jump(end_block, [])
+                
                 bcx.switch_to_block(end_block)
               when Bytecode::Insns::TestValuesInvert
-                no_match_block = bcx.create_block
-                post_length_check_block = bcx.create_block
-                post_not_equals_check_block = bcx.create_block
                 end_block = bcx.create_block
-                string_index_val = bcx.use_var(string_index)
-                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
-                bcx.jump(post_length_check_block, [])
+                after_checks_block = bcx.create_block
 
-                bcx.switch_to_block(post_length_check_block)
+                string_index_val = bcx.use_var(string_index)
+                bcx.def_var(flag, zero)
+                bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
+
+                jump_to_next_block(bcx)
                 char_ptr = bcx.iadd(string_pointer, string_index_val)
                 char = bcx.load(:I8, char_ptr, 0)
+
                 insn.chars.each do |value|
-                  new_block = bcx.create_block
-                  bcx.jump(new_block, [])
-                  bcx.switch_to_block(new_block)
+                  jump_to_next_block(bcx)
                   expected_char = bcx.iconst(:I8, value.ord)
-                  bcx.br_icmp(:e, char, expected_char, no_match_block, [])
+                  v = bcx.icmp(:e, char, expected_char)
+                  flag_val = bcx.select(v, zero, one)
+                  bcx.def_var(flag, flag_val)
+                  bcx.brz(flag_val, after_checks_block, [])
                 end
-                bcx.jump(post_not_equals_check_block, [])
+                bcx.jump(after_checks_block, [])
 
-                bcx.switch_to_block(post_not_equals_check_block)
-                increased = bcx.iadd(string_index_val, one)
+                bcx.switch_to_block(after_checks_block)
+                flag_val = bcx.use_var(flag)
+                increased = bcx.iadd(string_index_val, flag_val)
                 bcx.def_var(string_index, increased)
-                bcx.def_var(flag, one)
-                bcx.jump(end_block, [])
-
-                bcx.switch_to_block(no_match_block)
-                bcx.def_var(flag, zero)
+                bcx.def_var(flag, flag_val)
                 bcx.jump(end_block, [])
 
                 bcx.switch_to_block(end_block)
@@ -180,90 +204,73 @@ module RegularExpression
 
                 bcx.switch_to_block(end_block)
               when Bytecode::Insns::TestType
-                no_match_block = bcx.create_block
-                post_length_check_block = bcx.create_block
-                post_equal_check_block = bcx.create_block
                 end_block = bcx.create_block
-                string_index_val = bcx.use_var(string_index)
-                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
-                bcx.jump(post_length_check_block, [])
 
-                bcx.switch_to_block(post_length_check_block)
+                string_index_val = bcx.use_var(string_index)
+                bcx.def_var(flag, zero)
+                bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
+
+                jump_to_next_block(bcx)
                 char_ptr = bcx.iadd(string_pointer, string_index_val)
                 char = bcx.load(:I8, char_ptr, 0)
                 external_func_addr = bcx.iconst(:I64, insn.type.handle)
                 res = bcx.call_indirect(external_func_sigref, external_func_addr, [char])
                 values = bcx.inst_results(res)
-                bcx.br_icmp(:e, values[0], zero, no_match_block, [])
-                bcx.jump(post_equal_check_block, [])
+                flag_val = bcx.select(values[0], one, zero)
+                increased = bcx.iadd(string_index_val, flag_val)
 
-                bcx.switch_to_block(post_equal_check_block)
-                increased = bcx.iadd(string_index_val, one)
                 bcx.def_var(string_index, increased)
-                bcx.def_var(flag, one)
-                bcx.jump(end_block, [])
-
-                bcx.switch_to_block(no_match_block)
-                bcx.def_var(flag, zero)
+                bcx.def_var(flag, flag_val)
                 bcx.jump(end_block, [])
 
                 bcx.switch_to_block(end_block)
               when Bytecode::Insns::TestPositiveLookahead
-                no_match_block = bcx.create_block
-                post_length_check_block = bcx.create_block
                 end_block = bcx.create_block
-                string_index_val = bcx.use_var(string_index)
-                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
-                bcx.jump(post_length_check_block, [])
 
-                bcx.switch_to_block(post_length_check_block)
+                string_index_val = bcx.use_var(string_index)
+                bcx.def_var(flag, zero)
+                bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
+
+                jump_to_next_block(bcx)
                 char_ptr = bcx.iadd(string_pointer, string_index_val)
 
                 insn.value.each_char.with_index do |c, index|
                   # Move the correct character into the buffer
+                  jump_to_next_block(bcx)
                   lookahead = bcx.iconst(:I64, index)
                   char_ptr_ahead = bcx.iadd(char_ptr, lookahead)
                   char = bcx.load(:I8, char_ptr_ahead, 0)
                   expected_char = bcx.iconst(:I8, c.ord)
-                  bcx.br_icmp(:ne, char, expected_char, no_match_block, [])
-                  next_block = bcx.create_block
-                  bcx.jump(next_block, [])
-                  bcx.switch_to_block(next_block)
+                  v = bcx.icmp(:e, char, expected_char)
+                  flag_val = bcx.select(v, one, zero)
+                  bcx.def_var(flag, flag_val)
+                  bcx.brz(flag_val, end_block, [])
                 end
-
-                bcx.def_var(flag, one)
                 bcx.jump(end_block, [])
-
-                bcx.switch_to_block(no_match_block)
-                bcx.def_var(flag, zero)
-                bcx.jump(end_block, [])
-
                 bcx.switch_to_block(end_block)
               when Bytecode::Insns::TestNegativeLookahead
-                no_match_block = bcx.create_block
-                post_length_check_block = bcx.create_block
                 end_block = bcx.create_block
+
                 string_index_val = bcx.use_var(string_index)
                 bcx.def_var(flag, one)
                 bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
-                bcx.jump(post_length_check_block, [])
 
-                bcx.switch_to_block(post_length_check_block)
+                jump_to_next_block(bcx)
                 char_ptr = bcx.iadd(string_pointer, string_index_val)
+
                 insn.value.each_char.with_index do |c, index|
                   # Move the correct character into the buffer
+                  jump_to_next_block(bcx)
                   lookahead = bcx.iconst(:I64, index)
                   char_ptr_ahead = bcx.iadd(char_ptr, lookahead)
                   char = bcx.load(:I8, char_ptr_ahead, 0)
                   expected_char = bcx.iconst(:I8, c.ord)
-                  bcx.br_icmp(:ne, char, expected_char, end_block, [])
-                  next_block = bcx.create_block
-                  bcx.jump(next_block, [])
-                  bcx.switch_to_block(next_block)
+                  v = bcx.icmp(:ne, char, expected_char)
+                  flag_val = bcx.select(v, one, zero)
+                  bcx.def_var(flag, flag_val)
+                  bcx.brnz(flag_val, end_block, [])
                 end
-                bcx.def_var(flag, zero)
                 bcx.jump(end_block, [])
-
                 bcx.switch_to_block(end_block)
               when Bytecode::Insns::TestRangeInvert
                 no_match_block = bcx.create_block
@@ -337,7 +344,8 @@ module RegularExpression
         })
         b.finalize
         f_ptr = b.get_function_pointer(f)
-        Compiled.new(f_ptr)
+        f_size = b.get_function_size(f)
+        Compiled.new(f_ptr, f_size)
       end
     end
   end

--- a/lib/regular_expression/compiler/cranelift.rb
+++ b/lib/regular_expression/compiler/cranelift.rb
@@ -1,0 +1,384 @@
+# frozen_string_literal: true
+
+module RegularExpression
+  module Compiler
+    module Cranelift
+      class Compiled
+        attr_reader :f_ptr
+
+        def initialize(f_ptr)
+          @f_ptr = f_ptr
+        end
+
+        def to_proc
+          function = Fiddle::Function.new(@f_ptr, [Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T], Fiddle::TYPE_SIZE_T)
+          lambda do |string|
+            value = function.call(string, string.length)
+            value if value != string.length + 1
+          end
+        end
+      end
+
+      def self.compile(cfg, _schedule)
+        b = CraneliftRuby::CraneliftBuilder.new
+        s = b.make_signature(%i[I64 I64], [:I64])
+        external_func_sig = b.make_signature([:I8], [:I64])
+        f = b.make_function("regex", s, lambda { |bcx|
+          external_func_sigref = bcx.import_signature(external_func_sig)
+          initial_block = bcx.create_block
+          exit_block = bcx.create_block
+          bcx.append_block_params_for_function_params(initial_block)
+          bcx.switch_to_block(initial_block)
+
+          string_pointer = bcx.block_param(initial_block, 0)
+          string_length = bcx.block_param(initial_block, 1)
+
+          match_index = CraneliftRuby::Variable.new(0)
+          bcx.declare_var(match_index, :I64)
+          zero = bcx.iconst(:I64, 0)
+          one = bcx.iconst(:I64, 1)
+          bcx.def_var(match_index, zero)
+
+          string_index = CraneliftRuby::Variable.new(1)
+          bcx.declare_var(string_index, :I64)
+
+          flag = CraneliftRuby::Variable.new(2)
+          bcx.declare_var(flag, :I64)
+          bcx.def_var(flag, zero)
+
+          variables = []
+          cfg.backtracks.times do |i|
+            var = CraneliftRuby::Variable.new(3 + i)
+            bcx.declare_var(var, :I64)
+            variables << var
+          end
+
+          # start of our loop, check if we finished looking through the string
+          start_loop_head = bcx.create_block
+          bcx.jump(start_loop_head, [])
+          bcx.switch_to_block(start_loop_head)
+          match_index_val = bcx.use_var(match_index)
+          bcx.br_icmp(:sg, match_index_val, string_length, exit_block, [])
+          bcx.def_var(string_index, match_index_val)
+          block_map = {}
+
+          cfg.blocks.each do |block|
+            block_map[block.name] = bcx.create_block
+          end
+          bcx.jump(block_map[cfg.blocks[0].name], [])
+          cfg.blocks.each do |block|
+            bcx.switch_to_block(block_map[block.name])
+            block.insns.each do |insn|
+              case insn
+              when Bytecode::Insns::PushIndex
+                var = variables[insn.index]
+                string_index_val = bcx.use_var(string_index)
+                bcx.def_var(var, string_index_val)
+              when Bytecode::Insns::PopIndex
+                var = variables[insn.index]
+                var_val = bcx.use_var(var)
+                bcx.def_var(string_index, var_val)
+              when Bytecode::Insns::TestBegin
+                over_block = bcx.create_block
+                end_block = bcx.create_block
+
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, zero, over_block, [])
+
+                next_block = bcx.create_block
+                bcx.jump(next_block, [])
+                bcx.switch_to_block(next_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(over_block)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestEnd
+                over_block = bcx.create_block
+                end_block = bcx.create_block
+
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, over_block, [])
+
+                next_block = bcx.create_block
+                bcx.jump(next_block, [])
+                bcx.switch_to_block(next_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(over_block)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestAny
+                no_match_block = bcx.create_block
+                post_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_check_block, [])
+                bcx.switch_to_block(post_check_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestValue
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                post_equal_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                char = bcx.load(:I8, char_ptr, 0)
+                expected_char = bcx.iconst(:I8, insn.char.ord)
+                bcx.br_icmp(:ne, char, expected_char, no_match_block, [])
+                bcx.jump(post_equal_check_block, [])
+
+                bcx.switch_to_block(post_equal_check_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestValuesInvert
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                post_not_equals_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                char = bcx.load(:I8, char_ptr, 0)
+                insn.chars.each do |value|
+                  new_block = bcx.create_block
+                  bcx.jump(new_block, [])
+                  bcx.switch_to_block(new_block)
+                  expected_char = bcx.iconst(:I8, value.ord)
+                  bcx.br_icmp(:e, char, expected_char, no_match_block, [])
+                end
+                bcx.jump(post_not_equals_check_block, [])
+
+                bcx.switch_to_block(post_not_equals_check_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestRange
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                post_in_range_left_check_block = bcx.create_block
+                post_in_range_right_check_block = bcx.create_block
+
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                char = bcx.load(:I8, char_ptr, 0)
+                left_range_char = bcx.iconst(:I8, insn.left.ord)
+                right_range_char = bcx.iconst(:I8, insn.right.ord)
+                bcx.br_icmp(:sl, char, left_range_char, no_match_block, [])
+                bcx.jump(post_in_range_left_check_block, [])
+
+                bcx.switch_to_block(post_in_range_left_check_block)
+                bcx.br_icmp(:sg, char, right_range_char, no_match_block, [])
+                bcx.jump(post_in_range_right_check_block, [])
+
+                bcx.switch_to_block(post_in_range_right_check_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestType
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                post_equal_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                char = bcx.load(:I8, char_ptr, 0)
+                external_func_addr = bcx.iconst(:I64, insn.type.handle)
+                res = bcx.call_indirect(external_func_sigref, external_func_addr, [char])
+                values = bcx.inst_results(res)
+                bcx.br_icmp(:e, values[0], zero, no_match_block, [])
+                bcx.jump(post_equal_check_block, [])
+
+                bcx.switch_to_block(post_equal_check_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestPositiveLookahead
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+
+                insn.value.each_char.with_index do |c, index|
+                  # Move the correct character into the buffer
+                  lookahead = bcx.iconst(:I64, index)
+                  char_ptr_ahead = bcx.iadd(char_ptr, lookahead)
+                  char = bcx.load(:I8, char_ptr_ahead, 0)
+                  expected_char = bcx.iconst(:I8, c.ord)
+                  bcx.br_icmp(:ne, char, expected_char, no_match_block, [])
+                  next_block = bcx.create_block
+                  bcx.jump(next_block, [])
+                  bcx.switch_to_block(next_block)
+                end
+
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestNegativeLookahead
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.def_var(flag, one)
+                bcx.br_icmp(:e, string_index_val, string_length, end_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                insn.value.each_char.with_index do |c, index|
+                  # Move the correct character into the buffer
+                  lookahead = bcx.iconst(:I64, index)
+                  char_ptr_ahead = bcx.iadd(char_ptr, lookahead)
+                  char = bcx.load(:I8, char_ptr_ahead, 0)
+                  expected_char = bcx.iconst(:I8, c.ord)
+                  bcx.br_icmp(:ne, char, expected_char, end_block, [])
+                  next_block = bcx.create_block
+                  bcx.jump(next_block, [])
+                  bcx.switch_to_block(next_block)
+                end
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::TestRangeInvert
+                no_match_block = bcx.create_block
+                post_length_check_block = bcx.create_block
+                post_in_range_left_check_block = bcx.create_block
+                match_block = bcx.create_block
+
+                end_block = bcx.create_block
+                string_index_val = bcx.use_var(string_index)
+                bcx.br_icmp(:e, string_index_val, string_length, no_match_block, [])
+                bcx.jump(post_length_check_block, [])
+
+                bcx.switch_to_block(post_length_check_block)
+                char_ptr = bcx.iadd(string_pointer, string_index_val)
+                char = bcx.load(:I8, char_ptr, 0)
+                left_range_char = bcx.iconst(:I8, insn.left.ord)
+                bcx.br_icmp(:sl, char, left_range_char, match_block, [])
+                bcx.jump(post_in_range_left_check_block, [])
+
+                bcx.switch_to_block(post_in_range_left_check_block)
+                right_range_char = bcx.iconst(:I8, insn.right.ord)
+                bcx.br_icmp(:sle, char, right_range_char, no_match_block, [])
+                bcx.jump(match_block, [])
+
+                bcx.switch_to_block(match_block)
+                increased = bcx.iadd(string_index_val, one)
+                bcx.def_var(string_index, increased)
+                bcx.def_var(flag, one)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(no_match_block)
+                bcx.def_var(flag, zero)
+                bcx.jump(end_block, [])
+
+                bcx.switch_to_block(end_block)
+              when Bytecode::Insns::Branch
+                true_block = cfg.label_map[insn.true_target]
+                false_block = cfg.label_map[insn.false_target]
+                flag_val = bcx.use_var(flag)
+                bcx.br_icmp(:e, flag_val, one, block_map[true_block.name], [])
+                bcx.jump(block_map[false_block.name], [])
+              when Bytecode::Insns::Jump
+                target_block = cfg.label_map[insn.target]
+                bcx.jump(block_map[target_block.name], [])
+              when Bytecode::Insns::Match
+                # If we reach this instruction, then we've successfully matched
+                # against the input string, so we're going to return the integer
+                # that represents the index at which this match began
+                match_index_val = bcx.use_var(match_index)
+                bcx.return([match_index_val])
+              when Bytecode::Insns::Fail
+                match_index_val = bcx.use_var(match_index)
+                increased = bcx.iadd(one, match_index_val)
+                bcx.def_var(match_index, increased)
+                bcx.jump(start_loop_head, [])
+              when Bytecode::Insns::StartCapture
+                # raise NotImplementedError
+              when Bytecode::Insns::EndCapture
+                # raise NotImplementedError
+              else
+                print(insn)
+                raise
+              end
+            end
+          end
+          bcx.switch_to_block(exit_block)
+          res = bcx.iadd(one, string_length)
+          bcx.return([res])
+
+          bcx.finalize
+        })
+        b.finalize
+        f_ptr = b.get_function_pointer(f)
+        Compiled.new(f_ptr)
+      end
+    end
+  end
+end

--- a/regular_expression.gemspec
+++ b/regular_expression.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "cranelift_ruby"
   spec.add_dependency "fisk"
   spec.add_dependency "racc"
 end

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -20,6 +20,11 @@ module RegularExpression
         instance_eval(&block)
       end
 
+      define_method(:"test_#{name}_cranelift") do
+        @compiler = :cranelift
+        instance_eval(&block)
+      end
+
       define_method(:"test_#{name}_ruby") do
         @compiler = :ruby
         instance_eval(&block)
@@ -395,6 +400,8 @@ module RegularExpression
         pattern.profile(compiler: Compiler::Ruby, threshold: THRESHOLD)
       when :speculative_x86
         pattern.profile(compiler: Compiler::Ruby, threshold: THRESHOLD, speculative: true)
+      when :cranelift
+        pattern.compile(compiler: Compiler::Cranelift)
       end
 
       pattern


### PR DESCRIPTION
## Why this may be needed

Cranelift is pretty fast JIT code generator created for wasm runtimes that can target x86-64 and arm64 architectures (plus they may support other archs in the future). They also do some minimal amount of optimisations, like getting rid of jumps that go to the next block. 

## How did I add cranelift

I created a new gem `cranelift_ruby` that exposes enough apis from cranelift such that I could implement our compiler backend. The code for the compiler in `Compiler::Cranelift` is incredibly similar to what we do in the x86 one. 

I also had to add some additional information to the bytecode and cfg structures because I needed to know how many transitions we need and also added an index to each push and pop so that I know which variable to write and read from for each transition. 

I'll try to add more comments for the compiler, but I'm opening this to understand if we would like to have this in the first place. It does add one more compiler that we have to maintain (if we do not get rid of the x86 one) and it does add build dependencies (rust and cargo). At the same time, we get to target 2 backends at once (x86 and arm) and get all the benefits from additional optimisations and possibly new architectures without the need to do much on our side.

As of now the cranelift compiler passes all the tests we have and its similar in performance to the x86 compiler.