### PR TITLE
Implement captures for x86

### DIFF
--- a/lib/regular_expression/bytecode.rb
+++ b/lib/regular_expression/bytecode.rb
@@ -14,7 +14,9 @@ module RegularExpression
 
       visited = Set.new
       worklist = [[nfa, [:jump_to_fail]]]
-
+      n_of_captures = 0
+      captures = []
+      capture_names = []
       # For each state in the NFA.
       until worklist.empty?
         state, fallback = worklist.pop
@@ -48,13 +50,17 @@ module RegularExpression
             when NFA::Transition::EndAnchor
               builder.push(Insns::TestEnd.new)
             when NFA::Transition::StartCapture
+              captures << n_of_captures
+              capture_names << transition.name
               builder.push(
-                Insns::StartCapture.new(transition.name),
+                Insns::StartCapture.new(transition.name, n_of_captures),
                 Insns::Jump.new(label[transition.state])
               )
+              n_of_captures += 1
             when NFA::Transition::EndCapture
+              index = captures.pop
               builder.push(
-                Insns::EndCapture.new(transition.name),
+                Insns::EndCapture.new(transition.name, index),
                 Insns::Jump.new(label[transition.state])
               )
             when NFA::Transition::Any
@@ -130,6 +136,7 @@ module RegularExpression
       # We always have a failure case - it's just the failure instruction.
       builder.mark_label(:fail)
       builder.push(Insns::Fail.new)
+      builder.context = { n_of_captures: n_of_captures, capture_names: capture_names }
       builder.build
     end
 
@@ -151,8 +158,8 @@ module RegularExpression
       # otherwise clear it.
       TestEnd = Class.new
 
-      StartCapture = Struct.new(:name)
-      EndCapture = Struct.new(:name)
+      StartCapture = Struct.new(:name, :index)
+      EndCapture = Struct.new(:name, :index)
 
       # If it's possible to read a character off the input, then do so and set
       # the flag, otherwise clear it.
@@ -205,10 +212,12 @@ module RegularExpression
     class Builder
       attr_reader :insns # Array[Insns]
       attr_reader :labels # Hash[Symbol, Integer]
+      attr_accessor :context # { n_captures: Integer }
 
       def initialize
         @insns = []
         @labels = {}
+        @context = nil
       end
 
       def mark_label(label)
@@ -220,16 +229,17 @@ module RegularExpression
       end
 
       def build
-        Compiled.new(insns, labels)
+        Compiled.new(insns, labels, context)
       end
     end
 
     class Compiled
-      attr_reader :insns, :labels
+      attr_reader :insns, :labels, :context
 
-      def initialize(insns, labels)
+      def initialize(insns, labels, context)
         @insns = insns
         @labels = labels
+        @context = context
       end
 
       def dump

--- a/lib/regular_expression/cfg.rb
+++ b/lib/regular_expression/cfg.rb
@@ -114,7 +114,7 @@ module RegularExpression
       end
 
       start = blocks.values.first
-      Graph.new(start, exit_map.merge({ start.name => start }))
+      Graph.new(start, exit_map.merge({ start.name => start }), compiled.context)
     end
 
     def self.to_dot(cfg)
@@ -147,12 +147,13 @@ module RegularExpression
 
     # A graph is a set of EBBs.
     class Graph
-      attr_reader :start, :blocks, :label_map
+      attr_reader :start, :blocks, :label_map, :context
 
-      def initialize(start, label_map)
+      def initialize(start, label_map, context)
         @start = start
         @blocks = label_map.values.uniq
         @label_map = label_map
+        @context = context
       end
 
       def dump

--- a/lib/regular_expression/compiler/x86.rb
+++ b/lib/regular_expression/compiler/x86.rb
@@ -29,8 +29,8 @@ module RegularExpression
         end
 
         def to_proc
-          n_of_captures = context[:n_of_captures]
           capture_names = context[:capture_names]
+          n_of_captures = capture_names.length
           captures = ([-1] * (n_of_captures * 2)).pack("q*")
           function = buffer.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T, Fiddle::TYPE_VOIDP],
                                         Fiddle::TYPE_SIZE_T)

--- a/lib/regular_expression/compiler/x86.rb
+++ b/lib/regular_expression/compiler/x86.rb
@@ -5,9 +5,11 @@ module RegularExpression
     module X86
       class Compiled
         attr_reader :buffer
+        attr_reader :context
 
-        def initialize(buffer)
+        def initialize(buffer, context)
           @buffer = buffer
+          @context = context
         end
 
         def disasm
@@ -27,11 +29,18 @@ module RegularExpression
         end
 
         def to_proc
-          function = buffer.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T], Fiddle::TYPE_SIZE_T)
+          n_of_captures = context[:n_of_captures]
+          capture_names = context[:capture_names]
+          captures = ([-1] * (n_of_captures * 2)).pack("q*")
+          function = buffer.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T, Fiddle::TYPE_VOIDP], Fiddle::TYPE_SIZE_T)
 
           lambda do |string|
-            value = function.call(string, string.length)
-            value if value != string.length + 1
+            value = function.call(string, string.length, captures)
+            captures_result = {}
+            captures.unpack("q*").each_slice(2).with_index do |(s,e), i|
+              captures_result[capture_names[i]] = {start: s, end: e}
+            end
+            captures_result if value != string.length + 1
           end
         end
       end
@@ -55,9 +64,9 @@ module RegularExpression
           # string where we're currently looking
           string_index = rcx
 
-          # rdx is a scratch register that is used to track the index of the
+          # r12 is a scratch register that is used to track the index of the
           # string where we've started the match
-          match_index = rdx
+          match_index = r12
 
           # rsp is a reserved register that stores a pointer to the stack
           stack_pointer = rsp
@@ -73,6 +82,14 @@ module RegularExpression
           # rdi is a scratch register that stores the first argument to the
           # function, and in our case stores a pointer to the base of the string
           string_pointer = rdi
+
+          # rdx is a scratch register that stores the 3rd argument to the
+          # function, and in our case stores a pointer to the base of the captures array
+          captures_pointer = rdx
+
+          # r11 is a scratch register that stores the current position in the
+          # captures array
+          captures_pointer_buffer = r11
 
           # r8 is a scratch register that we're using to store the last read
           # character value from the string
@@ -146,9 +163,15 @@ module RegularExpression
                 mov flag, imm32(1)
                 make_label end_label
               when Bytecode::Insns::StartCapture
-                # raise NotImplementedError
+                index = insn.index * 16
+                mov captures_pointer_buffer, captures_pointer
+                add captures_pointer_buffer, imm32(index)
+                mov m64(captures_pointer_buffer), string_index
               when Bytecode::Insns::EndCapture
-                # raise NotImplementedError
+                index = insn.index * 16 + 8
+                mov captures_pointer_buffer, captures_pointer
+                add captures_pointer_buffer, imm32(index)
+                mov m64(captures_pointer_buffer), string_index
               when Bytecode::Insns::TestAny
                 no_match_label = :"no_match_#{insn.object_id}"
                 end_label = :"end_#{insn.object_id}"
@@ -459,7 +482,7 @@ module RegularExpression
         stringio.rewind
         stringio.each_byte(&buffer.method(:putc))
 
-        Compiled.new(buffer)
+        Compiled.new(buffer, cfg.context)
       end
     end
   end

--- a/lib/regular_expression/compiler/x86.rb
+++ b/lib/regular_expression/compiler/x86.rb
@@ -32,13 +32,14 @@ module RegularExpression
           n_of_captures = context[:n_of_captures]
           capture_names = context[:capture_names]
           captures = ([-1] * (n_of_captures * 2)).pack("q*")
-          function = buffer.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T, Fiddle::TYPE_VOIDP], Fiddle::TYPE_SIZE_T)
+          function = buffer.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T, Fiddle::TYPE_VOIDP],
+                                        Fiddle::TYPE_SIZE_T)
 
           lambda do |string|
             value = function.call(string, string.length, captures)
             captures_result = {}
-            captures.unpack("q*").each_slice(2).with_index do |(s,e), i|
-              captures_result[capture_names[i]] = {start: s, end: e}
+            captures.unpack("q*").each_slice(2).with_index do |(s, e), i|
+              captures_result[capture_names[i]] = { start: s, end: e }
             end
             captures_result if value != string.length + 1
           end
@@ -163,14 +164,14 @@ module RegularExpression
                 mov flag, imm32(1)
                 make_label end_label
               when Bytecode::Insns::StartCapture
-                index = insn.index * 16
+                capture_index = insn.index * 16
                 mov captures_pointer_buffer, captures_pointer
-                add captures_pointer_buffer, imm32(index)
+                add captures_pointer_buffer, imm32(capture_index)
                 mov m64(captures_pointer_buffer), string_index
               when Bytecode::Insns::EndCapture
-                index = insn.index * 16 + 8
+                capture_index = insn.index * 16 + 8
                 mov captures_pointer_buffer, captures_pointer
-                add captures_pointer_buffer, imm32(index)
+                add captures_pointer_buffer, imm32(capture_index)
                 mov m64(captures_pointer_buffer), string_index
               when Bytecode::Insns::TestAny
                 no_match_label = :"no_match_#{insn.object_id}"


### PR DESCRIPTION
## Why are we doing this

Fixes #83 

## How are we doing this

I've added a `context` field to the bytecode builder, the compiled result from bytecode transform, the cfg and the compiled result from x86 because we may need to share info in between these stages, such as the number of captures, the name of the captures (and possibly the number of transitions). 

Using the number of captures I create a packed array of signed 64bit integers that is passed down to the compiled code. Now that each `StartCapture` and `EndCapture` instruction has the index for the instruction to which it refers, we know where in memory to write in the captures array that is passed down. We do this for starting and ending a capture. 