### PR TITLE
Track transition index for push and pop index

### DIFF
--- a/lib/regular_expression/cfg.rb
+++ b/lib/regular_expression/cfg.rb
@@ -114,7 +114,7 @@ module RegularExpression
       end
 
       start = blocks.values.first
-      Graph.new(start, exit_map.merge({ start.name => start }), compiled.captures)
+      Graph.new(start, exit_map.merge({ start.name => start }), compiled.captures, compiled.n_of_transitions)
     end
 
     def self.to_dot(cfg)
@@ -147,13 +147,14 @@ module RegularExpression
 
     # A graph is a set of EBBs.
     class Graph
-      attr_reader :start, :blocks, :label_map, :captures
+      attr_reader :start, :blocks, :label_map, :captures, :n_of_transitions
 
-      def initialize(start, label_map, captures)
+      def initialize(start, label_map, captures, n_of_transitions)
         @start = start
         @blocks = label_map.values.uniq
         @label_map = label_map
         @captures = captures
+        @n_of_transitions = n_of_transitions
       end
 
       # Replace the block that an exits goes to.


### PR DESCRIPTION
## Why are we doing this

While implementing the cranelift backend I could not use the push and pop instructions that x86 provide, so I had to add additional information to the `PushIndex` and `PopIndex` instructions, plus record how many transitions are there that use these instructions so that I could preallocate enough stack memory for the implementation of `PushIndex` and `PopIndex`

## How we are doing this

I just extracted the logic I have in the cranelift PR and put it in a standalone PR. This information can also be used by the x86 compiler, but I would defer that to another PR. 