### PR TITLE
Make cranelift an optional dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     regular_expression (0.1.0)
-      cranelift_ruby
       fisk
       racc
 
@@ -12,8 +11,6 @@ GEM
     ast (2.4.2)
     crabstone (4.0.3)
       ffi
-    cranelift_ruby (0.1.6)
-      rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)
     fisk (2.1.0)
@@ -46,7 +43,6 @@ GEM
     rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
-    rutie (0.0.4)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Or install it yourself as:
 
 ### Dependencies
 
+#### Cranelift
+
+One of the backends that the regular expression compiler can use is cranelift, which is a rust project with Ruby bindings handled by the `cranelift_ruby` gem. In order to use the compiler, you'll need to have `cargo` installed so that it can compile the rust native extension. On a Mac or Linux you can `curl https://sh.rustup.rs -sSf | sh`. For other platforms, searching _install cargo_ can tell you how. Additionally, you'll need your Ruby to have been compiled with the `--enable-shared` option.
+
 #### Capstone
 
-To call `#disasm` on the generated machine code, you'll need Capstone installed. On a Mac you can `brew install capstone`, or on Ubuntu you can `sudo apt-get install libcapstone-dev`. For other platforms, Googling _install capstone_ can tell you how.
+To call `#disasm` on the generated machine code, you'll need Capstone installed. On a Mac you can `brew install capstone`, or on Ubuntu you can `sudo apt-get install libcapstone-dev`. For other platforms, searching _install capstone_ can tell you how.
 
 #### Graphviz
 
-To call `#to_dot` on the syntax tree or the state machines, or run the tests, you'll need Graphviz installed. On a Mac you can `brew install graphviz`, or on Ubuntu you can `sudo apt-get install graphviz`. For other platforms, Googling _install graphviz_ can tell you how.
+To call `#to_dot` on the syntax tree or the state machines, or run the tests, you'll need Graphviz installed. On a Mac you can `brew install graphviz`, or on Ubuntu you can `sudo apt-get install graphviz`. For other platforms, searching _install graphviz_ can tell you how.
 
 ## Usage
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -2,15 +2,12 @@ PATH
   remote: ..
   specs:
     regular_expression (0.1.0)
-      cranelift_ruby
       fisk
       racc
 
 GEM
   remote: https://rubygems.org/
   specs:
-    cranelift_ruby (0.1.1)
-      rutie (~> 0.0.4)
     docile (1.4.0)
     ffi (1.15.3)
     fisk (2.0.0)
@@ -36,7 +33,6 @@ GEM
       rack (>= 1.0, < 3)
     rake (13.0.6)
     ruby2_keywords (0.0.5)
-    rutie (0.0.4)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/regular_expression.rb
+++ b/lib/regular_expression.rb
@@ -4,7 +4,6 @@ require "fiddle"
 require "fisk"
 require "fisk/helpers"
 require "set"
-require "cranelift_ruby"
 require "stringio"
 require "strscan"
 

--- a/regular_expression.gemspec
+++ b/regular_expression.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cranelift_ruby"
   spec.add_dependency "fisk"
   spec.add_dependency "racc"
 end

--- a/test/regular_expression/matching_test.rb
+++ b/test/regular_expression/matching_test.rb
@@ -20,9 +20,11 @@ module RegularExpression
         instance_eval(&block)
       end
 
-      define_method(:"test_#{name}_cranelift") do
-        @compiler = :cranelift
-        instance_eval(&block)
+      if Compiler::Cranelift.enabled?
+        define_method(:"test_#{name}_cranelift") do
+          @compiler = :cranelift
+          instance_eval(&block)
+        end
       end
 
       define_method(:"test_#{name}_ruby") do


### PR DESCRIPTION
I can't get this thing to run locally because my ruby wasn't compiled with `--enable-shared`. I'd imagine this will be a pretty common case for a lot of folks, so I've added some code to make it an "optional" dependency, which is just to say the user must have required it before they attempt to call `compile(compiler: RegularExpression::Compiler::Cranelift)`.