### PR TITLE
Add blocks support to bytecode builder

### DIFF
--- a/lib/regular_expression/bytecode.rb
+++ b/lib/regular_expression/bytecode.rb
@@ -232,8 +232,9 @@ module RegularExpression
       Deoptimize = Class.new
     end
 
-    class Block 
+    class Block
       attr_reader :insns # Array[Insns]
+
       def initialize
         @insns = []
       end
@@ -262,9 +263,9 @@ module RegularExpression
 
       def switch_to_block(label)
         if blocks_map.key?(label)
-          current_block = blocks_map[label]
+          @current_block = blocks_map[label]
         else
-          current_block = blocks.length
+          @current_block = blocks.length
           blocks.push(Block.new)
           blocks_map[label] = current_block
           inverse_blocks_map[current_block] = label


### PR DESCRIPTION
I was thinking about the possible ways to solve #47 and #97 which are related to how we do not produce the right code for fallbacks, as when we visit an already visited state we just skip, whereas we would probably need at least record that we can reach that state with a specific fallback. 

I was thinking that we could record each fallback that a state may have depending from which state it was entered from and then, in a different loop generate the right fallback logic for each state. In order to do so, we would probably need to be able to add more code to each "block" of bytecode (block being a label and the code after it and before the next).

The current implementation would not allow to do so, so I added some sort of block support to the bytecode builder, so that we can switch from and to a block at any time before we call the `build` method on the builder.